### PR TITLE
test: Fix test on Linux

### DIFF
--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -51,7 +51,7 @@ fn test_chocolatey() {
 #[test]
 fn test_apt() {
     let apt = managers::AdvancedPackageTool;
-    if let Ok(apt) = apt.verify() {
+    if let Some(apt) = apt.verify() {
         let pkg = "hello";
         // sync
         assert!(apt.sync().success());


### PR DESCRIPTION
`verify` return `Option` and not `Result`