### PR TITLE
feat: JSON output support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,15 @@ strum = { version = "0.26", features = ["derive"] }
 tabled = "0.15"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+serde = { version = "1.0.197", features = ["derive"], optional = true }
+serde_json = {version = "1.0.115", optional = true }
 
 [features]
-default = ["verify"]
+default = ["cli"]
+cli = ["verify", "json"]
 verify = []
+serde = ["dep:serde"]
+json = ["serde", "dep:serde_json"]
 
 [dev-dependencies]
 tracing-test = "0.2.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,14 @@ use std::{
     process::{Child, Command, ExitStatus, Output},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod managers;
 
+#[cfg(feature = "cli")]
 pub mod utils;
+#[cfg(feature = "cli")]
 pub use utils::PkgManagerHandler;
 
 #[cfg(feature = "verify")]
@@ -294,6 +299,7 @@ pub trait Commands {
 ///
 /// All the variants are the type of commands that a type that imlements
 /// [``Commands``] and [``PackageManager``] (should) support.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Cmd {
     Install,
@@ -312,6 +318,7 @@ pub enum Cmd {
 /// It can be constructed with any type that implements `Into<Cow<sr>>`, for
 /// example, `&str` and `String`. `Package::from("python")` or with version,
 /// `Package::from("python").with_version("3.10.0")`.
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Package<'a> {
     name: Cow<'a, str>,
@@ -366,6 +373,7 @@ impl Display for Package<'_> {
 }
 
 /// Operation type to execute using [``Package::exec_op``]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Operation {
     Install,

--- a/src/managers/apt.rs
+++ b/src/managers/apt.rs
@@ -1,6 +1,8 @@
+use crate::{Cmd, Commands, Package, PackageManager, RepoError};
 use std::{fmt::Display, fs, io::Write, process::Command};
 
-use crate::{Cmd, Commands, Package, PackageManager, RepoError};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Wrapper for Advanced Pacakge Tool (APT), the default package management
 /// user-facing utilities in Debian and Debian-based distributions.
@@ -14,6 +16,7 @@ use crate::{Cmd, Commands, Package, PackageManager, RepoError};
 /// Another notable point is that the [``AdvancedPackageTool::add_repo``]
 /// implementation doesn't execute commands, but it writes to
 /// "/etc/apt/sources.list".
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub struct AdvancedPackageTool;
 

--- a/src/managers/dnf.rs
+++ b/src/managers/dnf.rs
@@ -2,12 +2,16 @@ use std::{fmt::Display, process::Command};
 
 use crate::{Cmd, Commands, Package, PackageManager, RepoError};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Wrapper for DandifiedYUM or DNF, the next upcoming major version of YUM
 ///
 /// [DNF, the next-generation replacement for YUM — dnf latest documentation](https://dnf.readthedocs.io/en/latest/)
 /// # Idiosyncracies
 /// The [``DandifiedYUM::add_repo``] method also installs `config-manager`
 /// plugin for DNF before attempting to add a repo.
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub struct DandifiedYUM;
 

--- a/src/managers/yum.rs
+++ b/src/managers/yum.rs
@@ -2,6 +2,9 @@ use std::{fmt::Display, process::Command};
 
 use crate::{managers::DandifiedYUM, Cmd, Commands, PackageManager};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Wrapper for Yellowdog Updater Modified (YUM) package manager.
 ///
 /// [Chapter 14. YUM (Yellowdog Updater Modified) Red Hat Enterprise Linux 5 | Red Hat Customer Portal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/c1-yum)
@@ -9,6 +12,7 @@ use crate::{managers::DandifiedYUM, Cmd, Commands, PackageManager};
 /// Note: The current YUM implementation uses [``DandifiedYUM``]'s
 /// implementation under the hood, which is why this struct is required to be
 /// constructed by calling [``YellowdogUpdaterModified::default()``].
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub struct YellowdogUpdaterModified {
     dnf: DandifiedYUM,

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -4,7 +4,11 @@ use std::{fmt::Display, process::Command};
 
 use crate::{Cmd, Commands, Package, PackageManager, RepoError};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Wrapper for Zypper package manager. Some openSUSE might support dnf as well.
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub struct Zypper;
 

--- a/src/utils/manager.rs
+++ b/src/utils/manager.rs
@@ -3,6 +3,9 @@ use std::fmt::Display;
 use clap::ValueEnum;
 use strum::{EnumCount, EnumIter};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     managers::{
         AdvancedPackageTool, Chocolatey, DandifiedYUM, Homebrew, YellowdogUpdaterModified, Zypper,
@@ -38,6 +41,7 @@ macro_rules! if_cfg {
 ///
 /// Adding support to a new package manager involves creating a new variant of
 /// its name and writing the appropriate [``Manager::init``] implementation.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCount, ValueEnum)]
 #[value(rename_all = "lower")]
 #[non_exhaustive]
@@ -108,7 +112,8 @@ impl Display for Manager {
 }
 
 /// Pkg Format.
-#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub enum PkgFormat {
     Bottle,
     Exe,

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -19,6 +19,14 @@ pub struct Cli {
         long_help = "Optionally specify a package manager mpm should use. When no package manager is provided, a default available one is picked automatically."
     )]
     pub manager: Option<Manager>,
+    #[cfg(feature = "json")]
+    #[arg(
+        short,
+        long,
+        help = "Print JSON to stdout instead of formatted text",
+        long_help = "Use JSON output instead of formatted text. Note: the flag will be ignored when used with unsupported commands."
+    )]
+    pub json: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -25,10 +25,14 @@
 //! `MyPackageMan::new().verify()` or `MyPackageMan::new().verify_dyn()`.
 use std::{fmt::Display, ops::Deref, process::Stdio};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::PackageManager;
 
 /// Wraps `T` that implements [``PackageManager``] and only constructs an
 /// instance if the given package manager is installed / is in path.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Verified<T> {
     inner: T,


### PR DESCRIPTION
This PR adds JSON output support to the mpm CLI.

## Notable changes (cargo features):
- utils module placed under `cli` feature to separate CLI functionality from the library
- New `serde` feature derives `Serialize` and `Deserialize` on most types exposed by the library
- JSON support is placed under `json` feature (enables `serde` feature, and `serde_json` dependency)
- CLI feature enabled by default, which means all features are enabled by default

## JSON output behavior
Passing `-j` or `--json` flag to `mpm` before any command will change the output to JSON (only on supported commands). The flag is ignored if the command doesn't support it.

Currently supported commands include:
- `managers`
- `list`
- `search`

Example output for `mpm --json managers` command
```json
[
  {
    "name": "Brew",
    "available": false,
    "file_extensions": [
      "Bottle"
    ]
  },
  {
    "name": "Choco",
    "available": false,
    "file_extensions": [
      "Exe",
      "Msi"
    ]
  },
  {
    "name": "Apt",
    "available": false,
    "file_extensions": [
      "Deb"
    ]
  },
  {
    "name": "Dnf",
    "available": false,
    "file_extensions": [
      "Rpm"
    ]
  },
  {
    "name": "Yum",
    "available": false,
    "file_extensions": [
      "Rpm"
    ]
  },
  {
    "name": "Zypper",
    "available": false,
    "file_extensions": [
      "Rpm"
    ]
  }
```