### PR TITLE
feat: allow installation of unsigned packages

### DIFF
--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -103,7 +103,7 @@ impl PackageManagerCommands for Zypper {
 
         // run zypper in non-interactive mode.
         cmd.insert(0, "-n".to_string());
-        if pkg.and_then(|p| p.url()).is_some() {
+        if pkg.is_some() {
             cmd.insert(1, "--no-gpg-checks".to_string());
         }
         cmd


### PR DESCRIPTION
Could be a security risk. Hide this option behind a flag in later release. 