### PR TITLE
feat: enable ANSI support in the tabled crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ sudo = "0.6"
 xmltree = "0.10"
 os_info = "3.8.2"
 strum = { version = "0.26", features = ["derive"] }
-tabled = "0.15"
+tabled = { version = "0.15", features = ["ansi"] }
 tracing = "0.1.40"
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }


### PR DESCRIPTION
Added ANSI support to the table crate, so that the table in the `mpm mangers` command can be rendered properly

before:
![before](https://github.com/user-attachments/assets/10a0c3b2-a708-45c8-b899-1c2c1d568152)

after:
![after](https://github.com/user-attachments/assets/4a0ccd2c-7efc-4f34-bfe9-9f2b39f5b041)

